### PR TITLE
Move pagination class from div to ul

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -161,7 +161,7 @@ function paginate(argOpts) {
     var html = [];
     
     // begin
-    html.push('<div class="pagination"><ul>');
+    html.push('<div><ul class="pagination">');
     html.push(opts.addSep);
     
     // first


### PR DESCRIPTION
[Bootstrap's documentation](http://getbootstrap.com/components/#pagination) shows the "pagination" class attribute applied to the `<ul>`.  In my app, the Bootstrap pagination styling was broken until making this change.
